### PR TITLE
Use psql from PATH

### DIFF
--- a/packaged/lisk_snapshot.sh
+++ b/packaged/lisk_snapshot.sh
@@ -188,9 +188,9 @@ until tail -n10 "$LOG_LOCATION" | (grep -q "Snapshot finished"); do
 	MINUTES=$(( MINUTES + 1 ))
 	if (( MINUTES % PGSQL_VACUUM_DELAY == 0 )) 2> /dev/null; then
 		echo -e "\\n$(now) Executing vacuum on table 'mem_round' of database '$TARGET_DB_NAME'"
-		DBSIZE1=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
+		DBSIZE1=$(( $( psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
 		vacuumdb --analyze --full --table 'mem_round' "$TARGET_DB_NAME" &> /dev/null
-		DBSIZE2=$(( $( ./pgsql/bin/psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
+		DBSIZE2=$(( $( psql -d "$TARGET_DB_NAME" -t -c "select pg_database_size('$TARGET_DB_NAME');" | xargs ) / 1024 / 1024 ))
 		echo -e "$(now) Vacuum completed, database size: $DBSIZE1 MB => $DBSIZE2 MB"
 	fi
 done


### PR DESCRIPTION
From @webmaster128 

This script already adds $(pwd)/pgsql/bin to PATH via env.sh. With this change, the system's pgsql can be used as a fallback.

I ask to apply this change on master since I need this fix for 0.9.x nodes and if I understood development correctly, it is already incompatible with 0.9.x

This was already merged into the development branch and just needs to be applied to master as well