### PR TITLE
Rely on lisk core shutting down for ending snapshotting process

### DIFF
--- a/packaged/lisk_snapshot.sh
+++ b/packaged/lisk_snapshot.sh
@@ -174,7 +174,7 @@ echo -e "\\n$(now) Beginning snapshot verification process"
 bash lisk.sh start -p "$PM2_CONFIG"
 
 MINUTES=0
-until (grep -Eq 'Snapshot creation finished|Snapshot finished' "$LOG_LOCATION"); do
+until [[ ! $(pm2 info lisk.snapshot | grep status | awk '{print $4}') == "stopped" ]];  do
 	sleep 60
 
 	if [ "$( stat --format=%Y "$LOG_LOCATION" )" -le $(( $(date +%s) - ( STALL_THRESHOLD_CURRENT * 60 ) )) ]; then


### PR DESCRIPTION
Use pm2 status for knowing when snapshotting has ended - Closes #81 