### PR TITLE
Wait for Postgres to be ready when starting server

### DIFF
--- a/packaged/lisk.sh
+++ b/packaged/lisk.sh
@@ -205,7 +205,7 @@ start_postgresql() {
 	if pgrep -x "postgres" > /dev/null 2>&1; then
 		echo "√ Postgresql is running."
 	else
-		if ! pg_ctl -D "$DB_DATA" -l "$DB_LOG_FILE" start >> "$SH_LOG_FILE" 2>&1; then
+		if ! pg_ctl -w -D "$DB_DATA" -l "$DB_LOG_FILE" start >> "$SH_LOG_FILE" 2>&1; then
 			echo "X Failed to start Postgresql."
 			exit 1
 		else


### PR DESCRIPTION
As you can see in this log from yesterday

```
:~$ bash installLisk.sh install -r test
Checking prerequisites:
curl is installed. Passed
Tar is installed. Passed
All preqrequisites passed!
Where do you want to install Lisk to? (Default /home/testnet):
Would you like to synchronize from the Genesis Block? (Default no):

Downloading current Lisk binaries: lisk-Linux-x86_64.tar.gz
######################################################################## 100.0%

Checksum Passed!

Extracting Lisk binaries to /home/testnet/lisk-test

Cleaning up downloaded files

Coldstarting Lisk for the first time
√ Postgresql started successfully.
√ Postgresql user created successfully.
√ Postgresql database created successfully.
√ Using Local Snapshot.
Restoring blockchain with /home/testnet/lisk-test/var/db/blockchain.db.gz
√ Blockchain restored successfully.
√ Crontab updated successfully.
√ Lisk started successfully.
√ Lisk is running as PID: 5817
ERROR: relation "blocks" does not exist
LINE 1: select height from blocks order by height desc limit 1;
^
Current Block Height: Unavailable

Stopping Lisk to perform database tuning
√ Lisk stopped successfully.
√ Postgresql stopped successfully.

Executing database tuning operation
Updates completed

Starting Lisk with official snapshot
√ Lisk stopped successfully.
√ Postgresql started successfully.
X Failed to create Postgresql database.
```

the installation creates a database and restores a snapshot twice. The first succeeds but then the second fails. This means all permissions should be fine.

Unfortunately I don't have the corresponding logs/lisk.log, but I guess the issue is that Postgresql is not ready for connections after "√ Postgresql started successfully.". This is because

> -w
>
> Wait for the startup or shutdown to complete. Waiting is the default option for shutdowns, but not startups. When waiting for startup, pg_ctl repeatedly attempts to connect to the server. [...] pg_ctl returns an exit code based on the success of the startup or shutdown.

https://www.postgresql.org/docs/9.6/static/app-pg-ctl.html

Even if that was not the only problem, setting `-w` when starting the server should be done anyway in this script.