### PR TITLE
Update min-uptime for pm2 to compensate chain validation time - Closes #119

### DIFF
--- a/packaged/etc/pm2-lisk.json
+++ b/packaged/etc/pm2-lisk.json
@@ -12,7 +12,7 @@
                 "max_memory_restart": "1024M",
                 "node_args": "--max_old_space_size=1024",
                 "args": "-c config.json",
-                "min_uptime": 3000,
+                "min_uptime": 20000,
                 "max_restarts": 10
         }]
 }


### PR DESCRIPTION
This change will make sure that our application should do all preliminary steps and start within 20 seconds. If some failure caught before 20s, pm2 will restart and counted in restarts. If application exit after 20 seconds then it will be restarted but didn't counted in maximum restarts. 

Closes: #119 