### PR TITLE
Update the usage of installLisk.sh

### DIFF
--- a/downloaded/installLisk.sh
+++ b/downloaded/installLisk.sh
@@ -277,10 +277,11 @@ upgrade_lisk() {
 }
 
 usage() {
-	echo "Usage: $0 <install|upgrade> [-d <directory] [-r <main|test|dev>] [-n] [-h [-u <URL>]] [-c]"
+	echo "Usage: $0 <install|upgrade> [-d <directory>] [-f <FILE>] [-r <main|test|dev>] [-n] [-h [-u <URL>]] [-0 <yes|no>] [-c]"
 	echo "install         -- install Lisk"
 	echo "upgrade         -- upgrade Lisk"
 	echo " -d <DIRECTORY> -- install location"
+	echo " -f <FILE>      -- use a local tarball to install"
 	echo " -r <RELEASE>   -- choose main or test"
 	echo " -h             -- rebuild instead of copying database"
 	echo " -u <URL>       -- URL to rebuild from - Requires -h"

--- a/downloaded/installLisk.sh
+++ b/downloaded/installLisk.sh
@@ -277,7 +277,7 @@ upgrade_lisk() {
 }
 
 usage() {
-	echo "Usage: $0 <install|upgrade> [-d <directory>] [-f <FILE>] [-r <main|test|dev>] [-n] [-h [-u <URL>]] [-0 <yes|no>] [-c]"
+	echo "Usage: $0 <install|upgrade> [-d <DIRECTORY>] [-f <FILE>] [-r <main|test|dev>] [-n] [-h [-u <URL>]] [-0 <yes|no>] [-c]"
 	echo "install             -- install Lisk"
 	echo "upgrade             -- upgrade Lisk"
 	echo " -d <DIRECTORY>     -- install location"

--- a/downloaded/installLisk.sh
+++ b/downloaded/installLisk.sh
@@ -285,8 +285,8 @@ usage() {
 	echo " -r <main|test|dev> -- choose network (default: main)"
 	echo " -h                 -- rebuild instead of copying database"
 	echo " -u <URL>           -- URL to rebuild from - Requires -h"
-	echo " -0 <yes|no>        -- Forces sync from 0 (default: no)"
-	echo " -c                 -- Clean database after upgrade"
+	echo " -0 <yes|no>        -- force sync from 0 (default: no)"
+	echo " -c                 -- clean database after upgrade"
 }
 
 parse_option() {

--- a/downloaded/installLisk.sh
+++ b/downloaded/installLisk.sh
@@ -278,15 +278,15 @@ upgrade_lisk() {
 
 usage() {
 	echo "Usage: $0 <install|upgrade> [-d <directory>] [-f <FILE>] [-r <main|test|dev>] [-n] [-h [-u <URL>]] [-0 <yes|no>] [-c]"
-	echo "install         -- install Lisk"
-	echo "upgrade         -- upgrade Lisk"
-	echo " -d <DIRECTORY> -- install location"
-	echo " -f <FILE>      -- use a local tarball to install"
-	echo " -r <RELEASE>   -- choose main or test"
-	echo " -h             -- rebuild instead of copying database"
-	echo " -u <URL>       -- URL to rebuild from - Requires -h"
-	echo " -0 <yes|no>    -- Forces sync from 0"
-	echo " -c             -- Clean database after upgrade"
+	echo "install             -- install Lisk"
+	echo "upgrade             -- upgrade Lisk"
+	echo " -d <DIRECTORY>     -- install location"
+	echo " -f <FILE>          -- use a local tarball to install"
+	echo " -r <main|test|dev> -- choose network (default: main)"
+	echo " -h                 -- rebuild instead of copying database"
+	echo " -u <URL>           -- URL to rebuild from - Requires -h"
+	echo " -0 <yes|no>        -- Forces sync from 0 (default: no)"
+	echo " -c                 -- Clean database after upgrade"
 }
 
 parse_option() {


### PR DESCRIPTION
## What was the problem?

* Users couldn't know the `-f` option unless they carefully read the code.


## How did I fix it?

* Add the explanation of `-f` option.
* Unify the writing: 
  * Use the lowercase in beginning of the explanation.
  * Use uppercase for variables like `DIRECTORY` or `FILE`.
  * verb: forces -> force
* Update the explanation of `-r` option because it's not just the main or test now.
* Show default values because users (and I) can't know whether options must be set.


## How to test it?

I confirmed whether the usage displays.

```sh
> bash downloaded/installLisk.sh --help                                                                                                            

✘ 1 update-usage
Error: Unrecognized command.                                                                                                                                                           

Available commands are: install upgrade
Usage: downloaded/installLisk.sh <install|upgrade> [-d <DIRECTORY>] [-f <FILE>] [-r <main|test|dev>] [-n] [-h [-u <URL>]] [-0 <yes|no>] [-c]
install             -- install Lisk
upgrade             -- upgrade Lisk
 -d <DIRECTORY>     -- install location
 -f <FILE>          -- use a local tarball to install
 -r <main|test|dev> -- choose network (default: main)
 -h                 -- rebuild instead of copying database
 -u <URL>           -- URL to rebuild from - Requires -h
 -0 <yes|no>        -- force sync from 0 (default: no)
 -c                 -- clean database after upgrade
```
