### PR TITLE
Update installLisk.sh

### DIFF
--- a/downloaded/installLisk.sh
+++ b/downloaded/installLisk.sh
@@ -45,7 +45,7 @@ prereq_checks() {
 		echo -e "curl is installed.\\t\\t\\t\\t\\tPassed"
 	else
 		echo -e "\\ncurl is not installed.\\t\\t\\t\\t\\tFailed"
-		echo -e "\\nPlease follow the Prerequisites at: https://docs.lisk.io/docs/core-pre-installation-binary"
+		echo -e "\\nPlease follow the Prerequisites at: https://lisk.io/documentation/lisk-core/setup/pre-install/binary"
 		exit 2
 	fi
 
@@ -53,7 +53,15 @@ prereq_checks() {
 		echo -e "Tar is installed.\\t\\t\\t\\t\\tPassed"
 	else
 		echo -e "\\ntar is not installed.\\t\\t\\t\\t\\tFailed"
-		echo -e "\\nPlease follow the Prerequisites at: https://docs.lisk.io/docs/core-pre-installation-binary"
+		echo -e "\\nPlease follow the Prerequisites at: https://lisk.io/documentation/lisk-core/setup/pre-install/binary"
+		exit 2
+	fi
+	
+	if [ -x "$(command -v jq)" ]; then
+		echo -e "Jq is installed.\\t\\t\\t\\t\\tPassed"
+	else
+		echo -e "\\njq is not installed.\\t\\t\\t\\t\\tFailed"
+		echo -e "\\nPlease follow the Prerequisites at: https://lisk.io/documentation/lisk-core/setup/pre-install/binary"
 		exit 2
 	fi
 


### PR DESCRIPTION
prerequisites check for jq + updated links to docs

Also, official docs are missing of jq. While there is no JQ this script proceeds with upgrade forcefully ending up with purged config of lisk core.